### PR TITLE
Bump minimum TLS from 1.0 to 1.2 (RFC 8996)

### DIFF
--- a/mysqld_exporter.go
+++ b/mysqld_exporter.go
@@ -584,7 +584,7 @@ func main() {
 		}
 	}
 
-	tlsMinVer := (web.TLSVersion)(tls.VersionTLS10)
+	tlsMinVer := (web.TLSVersion)(tls.VersionTLS12)
 	tlsMaxVer := (web.TLSVersion)(tls.VersionTLS13)
 	if tlsMinVersion != nil && *tlsMinVersion != "" {
 		if err := yaml.Unmarshal([]byte(*tlsMinVersion), &tlsMinVer); err != nil {


### PR DESCRIPTION
Test PR